### PR TITLE
Use Node 20 for running the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
     - uses: reviewdog/action-setup@v1
       with:
-        reviewdog_version: v0.20.1
+        reviewdog_version: v0.20.2
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:


### PR DESCRIPTION
Sometimes `linkspector` fails to install when Node version is < 20. 
```
🔗💀 Installing linkspector ... https://github.com/UmbrellaDocs/linkspector
  npm warn EBADENGINE Unsupported engine {
  npm warn EBADENGINE   package: 'glob@11.0.0',
  npm warn EBADENGINE   required: { node: '20 || >=22' },
  npm warn EBADENGINE   current: { node: 'v18.20.4', npm: '10.7.0' }
  npm warn EBADENGINE }
  npm warn EBADENGINE Unsupported engine {
  npm warn EBADENGINE   package: 'jackspeak@4.0.1',
  npm warn EBADENGINE   required: { node: '20 || >=22' },
  npm warn EBADENGINE   current: { node: 'v18.20.4', npm: '10.7.0' }
  npm warn EBADENGINE }
 ...
```

This PR sets node version as 20 