### PR TITLE
Add fail_level argument and deprecate fail_on_error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           level: error
-          fail_on_error: true
+          fail_level: any
       - name: check the exit code
         if: ${{ !success() }}
         run: echo 'The previous step should fail' && exit 1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This action runs [Linkspector](https://github.com/UmbrellaDocs/linkspector) with
            with:
              github_token: ${{ secrets.github_token }}
              reporter: github-pr-review
-             fail_on_error: true
+             fail_level: any
    ```
 
 ## Action inputs
@@ -57,10 +57,10 @@ For more details, see [Reporters](https://github.com/reviewdog/reviewdog?tab=rea
 
 For more details, please see [Filter mode support table](https://github.com/reviewdog/reviewdog?tab=readme-ov-file#filter-mode-support-table).
 
-### `fail_on_error`
+### `fail_level`
 
-(Optional)  Exit code for reviewdog when errors are found [true,false]
-Default is `false`.
+(Optional)  Exit code for reviewdog when errors are found with severity greater than or equal to the given level [none,any,info,warning,error].
+Default is `none`.
 
 ### `reviewdog_flags`
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ For more details, please see [Filter mode support table](https://github.com/revi
 (Optional)  Exit code for reviewdog when errors are found with severity greater than or equal to the given level [none,any,info,warning,error].
 Default is `none`.
 
+### `fail_on_error`
+
+(Optional, deprecated) Exit code for reviewdog when errors are found [true,false]. This option is ignored if `fail_level` is used.
+Default is `false`.
+
 ### `reviewdog_flags`
 
 (Optional) Additional reviewdog flags.

--- a/action.yml
+++ b/action.yml
@@ -23,11 +23,10 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
-  fail_on_error:
-    description: |
-      Exit code for reviewdog when errors are found [true,false].
-      Default is `false`.
-    default: 'false'
+  fail_level:
+      Exit code for reviewdog when errors are found with severity greater than or equal to the given level [none,any,info,warning,error].
+      Default is `none`.
+    default: 'none'
   reviewdog_flags:
     description: 'Additional reviewdog flags.'
     default: ''
@@ -54,7 +53,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
-        INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_CONFIG_FILE: ${{ inputs.config_file }}
 branding:

--- a/action.yml
+++ b/action.yml
@@ -50,13 +50,17 @@ runs:
       with:
         reviewdog_version: v0.20.3
     - run: |
-        if [ -n "${{ inputs.fail_level }}" ]; then
-          echo "INPUT_FAIL_LEVEL=${{ inputs.fail_level }}" >> $GITHUB_ENV
-        elif [ "${{ inputs.fail_on_error }}" = 'true' ]; then
-            echo 'INPUT_FAIL_LEVEL=any' >> $GITHUB_ENV
-        else
-            echo 'INPUT_FAIL_LEVEL=none' >> $GITHUB_ENV
-        fi
+         if [ -n "${INPUT_FAIL_LEVEL}" ]; then
+             echo "INPUT_FAIL_LEVEL=${INPUT_FAIL_LEVEL}" >> "${GITHUB_ENV}"
+         elif [ "${INPUT_FAIL_ON_ERROR}" = "true" ]; then
+             echo "INPUT_FAIL_LEVEL=any" >> "${GITHUB_ENV}"
+         else
+             echo "INPUT_FAIL_LEVEL=none" >> "${GITHUB_ENV}"
+         fi
+      shell: bash
+      env:
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
+        INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -1,47 +1,50 @@
-name: 'Run Linkspector with reviewdog'
-description: 'Run 💀Linkspector with 🐶reviewdog on pull requests to uncover broken links in your content.'
-author: 'Gaurav Nelson'
+---
+name: Run Linkspector with reviewdog
+description: Run 💀Linkspector with 🐶reviewdog on pull requests to uncover
+  broken links in your content.
+author: Gaurav Nelson
 inputs:
   github_token:
-    description: 'GITHUB_TOKEN'
-    default: '${{ github.token }}'
+    description: GITHUB_TOKEN
+    default: ${{ github.token }}
   workdir:
-    description: 'Working directory relative to the root directory.'
-    default: '.'
-  ### Flags for reviewdog ###
+    description: Working directory relative to the root directory.
+    default: .
   tool_name:
-    description: 'Tool name to use for reviewdog reporter.'
-    default: 'Linkspector'
+    description: Tool name to use for reviewdog reporter.
+    default: Linkspector
   level:
-    description: 'Report level for reviewdog [info,warning,error].'
-    default: 'error'
+    description: Report level for reviewdog [info,warning,error].
+    default: error
   reporter:
-    description: 'Reporter of reviewdog command [github-check,github-pr-review,github-pr-check].'
-    default: 'github-check'
+    description: Reporter of reviewdog command [github-check,github-pr-review,github-pr-check].
+    default: github-check
   filter_mode:
-    description: |
-      Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
-      Default is added.
-    default: 'added'
+    description: >
+      Filtering mode for the reviewdog command
+      [added,diff_context,file,nofilter]. Default is added.
+    default: added
   fail_level:
-      Exit code for reviewdog when errors are found with severity greater than or equal to the given level [none,any,info,warning,error].
-      Default is `none`.
-    default: ''
+    description: >
+      Exit code for reviewdog when errors are found with severity greater
+      than or equal to the given level [none,any,info,warning,error]. Default is
+      `none`.
+    default: ""
   fail_on_error:
-    description: |
-      (Deprecated) Exit code for reviewdog when errors are found [true,false]. This option is ignored if you use `fail_level`.
-      Default is `false`.
-    default: 'false'
+    description: >
+      (Deprecated) Exit code for reviewdog when errors are found
+      [true,false]. This option is ignored if you use `fail_level`. Default is
+      `false`.
+    default: "false"
   reviewdog_flags:
-    description: 'Additional reviewdog flags.'
-    default: ''
-  ### Flags for Linkspector ###
+    description: Additional reviewdog flags.
+    default: ""
   config_file:
-    description: 'Specify the path for the Linkspector YML configuration file.'
+    description: Specify the path for the Linkspector YML configuration file.
     required: true
-    default: '.linkspector.yml'
+    default: .linkspector.yml
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - uses: actions/setup-node@v4
       with:
@@ -50,13 +53,13 @@ runs:
       with:
         reviewdog_version: v0.20.3
     - run: |
-         if [ -n "${INPUT_FAIL_LEVEL}" ]; then
-             echo "INPUT_FAIL_LEVEL=${INPUT_FAIL_LEVEL}" >> "${GITHUB_ENV}"
-         elif [ "${INPUT_FAIL_ON_ERROR}" = "true" ]; then
-             echo "INPUT_FAIL_LEVEL=any" >> "${GITHUB_ENV}"
-         else
-             echo "INPUT_FAIL_LEVEL=none" >> "${GITHUB_ENV}"
-         fi
+        if [ -n "${INPUT_FAIL_LEVEL}" ]; then
+            echo "INPUT_FAIL_LEVEL=${INPUT_FAIL_LEVEL}" >> "${GITHUB_ENV}"
+        elif [ "${INPUT_FAIL_ON_ERROR}" = "true" ]; then
+            echo "INPUT_FAIL_LEVEL=any" >> "${GITHUB_ENV}"
+        else
+            echo "INPUT_FAIL_LEVEL=none" >> "${GITHUB_ENV}"
+        fi
       shell: bash
       env:
         INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
@@ -74,5 +77,5 @@ runs:
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_CONFIG_FILE: ${{ inputs.config_file }}
 branding:
-  icon: 'link-2'
-  color: 'blue'
+  icon: link-2
+  color: blue

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,12 @@ inputs:
   fail_level:
       Exit code for reviewdog when errors are found with severity greater than or equal to the given level [none,any,info,warning,error].
       Default is `none`.
-    default: 'none'
+    default: ''
+  fail_on_error:
+    description: |
+      (Deprecated) Exit code for reviewdog when errors are found [true,false]. This option is ignored if you use `fail_level`.
+      Default is `false`.
+    default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags.'
     default: ''
@@ -44,6 +49,14 @@ runs:
     - uses: reviewdog/action-setup@v1
       with:
         reviewdog_version: v0.20.3
+    - run: |
+        if [ -n "${{ inputs.fail_level }}" ]; then
+          echo "INPUT_FAIL_LEVEL=${{ inputs.fail_level }}" >> $GITHUB_ENV
+        elif [ "${{ inputs.fail_on_error }}" = 'true' ]; then
+            echo 'INPUT_FAIL_LEVEL=any' >> $GITHUB_ENV
+        else
+            echo 'INPUT_FAIL_LEVEL=none' >> $GITHUB_ENV
+        fi
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:
@@ -53,7 +66,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
-        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
+        INPUT_FAIL_LEVEL: ${{ env.INPUT_FAIL_LEVEL }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_CONFIG_FILE: ${{ inputs.config_file }}
 branding:

--- a/script.sh
+++ b/script.sh
@@ -28,7 +28,7 @@ linkspector check -c "${INPUT_CONFIG_FILE}" -j |
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \
     -filter-mode="${INPUT_FILTER_MODE}" \
-    -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+    -fail-level="${INPUT_FAIL_LEVEL}" \
     -level="${INPUT_LEVEL}" \
     "${INPUT_REVIEWDOG_FLAGS}"
 exit_code=$?


### PR DESCRIPTION
Closes #24.

This PR has two commits to make it easier to review:
- commit f61f30c601204fd33ec15dddfae029945f997a9f adds the `fail_level` option in the first commit
- commit 21ae05fd261598bcfea43fb0cacf63242cf91fec maintains backwards-compatibility to avoid breaking any current GitHub Actions users who are calling with `fail_on_error=true`.

If backwards-compatibility isn't important, we can just go with the first commit and reduce the code complexity.