### PR TITLE
Update action runtime to node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,9 +50,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
-        node-version: 20
+        node-version: 24
     - uses: reviewdog/action-setup@v1
       with:
         reviewdog_version: v0.21.0


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/