### PR TITLE
feat: enhance reviewdog setup with caching and version management

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,9 +53,31 @@ runs:
     - uses: actions/setup-node@v5
       with:
         node-version: 24
-    - uses: reviewdog/action-setup@v1
+    - name: Set reviewdog version
+      id: reviewdog-version
+      run: echo "reviewdog_version=v0.21.0" >> "$GITHUB_OUTPUT"
+      shell: bash
+    - name: Cache reviewdog binary
+      id: cache-reviewdog
+      uses: actions/cache@v4
       with:
-        reviewdog_version: v0.21.0
+        path: ~/reviewdog-bin
+        key: reviewdog-${{ runner.os }}-${{ runner.arch }}-${{ steps.reviewdog-version.outputs.reviewdog_version }}
+    - name: Install reviewdog
+      if: steps.cache-reviewdog.outputs.cache-hit != 'true'
+      uses: reviewdog/action-setup@v1
+      with:
+        reviewdog_version: ${{ steps.reviewdog-version.outputs.reviewdog_version }}
+    - name: Copy reviewdog to cache location
+      if: steps.cache-reviewdog.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p ~/reviewdog-bin
+        cp "$(which reviewdog)" ~/reviewdog-bin/
+      shell: bash
+    - name: Add cached reviewdog to PATH
+      if: steps.cache-reviewdog.outputs.cache-hit == 'true'
+      run: echo "$HOME/reviewdog-bin" >> $GITHUB_PATH
+      shell: bash
     - run: |
         if [ -n "${INPUT_FAIL_LEVEL}" ]; then
             echo "INPUT_FAIL_LEVEL=${INPUT_FAIL_LEVEL}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
This pull request updates the way the `reviewdog` tool is installed and cached in the GitHub Actions workflow, optimizing for faster and more reliable builds by leveraging caching. The main change is replacing the direct setup of `reviewdog` with a cache-aware installation process.

**Improvements to reviewdog setup and caching:**

* Added steps to set the `reviewdog` version as an output variable, enabling consistent versioning throughout the workflow.
* Implemented a caching mechanism using `actions/cache@v4` to store the `reviewdog` binary in `~/reviewdog-bin`, reducing redundant downloads and speeding up subsequent runs.
* Modified the installation step to only run if the cache was not hit, preventing unnecessary installations.
* Added a step to copy the installed `reviewdog` binary to the cache location when the cache is missed, and a step to add the cached binary to the `PATH` when the cache is hit.

fixes #50 