### PR TITLE
chore: update actions/checkout to v5 across all workflows

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -10,7 +10,7 @@ jobs:
   reviewdog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: reviewdog/action-depup/with-pr@v1
         with:
           file: action.yml

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Manage labels
         uses: lannonbr/issue-label-manager-action@4.0.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
@@ -51,6 +51,6 @@ jobs:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Post bumpr status comment
         uses: haya14busa/action-bumpr@v1

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,7 +9,7 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: haya14busa/action-cond@v1
         id: reporter
         with:
@@ -25,14 +25,14 @@ jobs:
     name: runner / shfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: reviewdog/action-shfmt@v1
 
   actionlint:
     name: runner / actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: github-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: runner / linkspector (github-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -24,7 +24,7 @@ jobs:
     name: runner / linkspector (github-pr-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -36,7 +36,7 @@ jobs:
     name: runner / linkspector (github-pr-review)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./
         continue-on-error: true
         with:

--- a/.github/workflows/update-linkspector-version.yml
+++ b/.github/workflows/update-linkspector-version.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get current linkspector version from script
         id: get_current_version

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action runs [Linkspector](https://github.com/UmbrellaDocs/linkspector) with
        name: runner / linkspector
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v5
          - name: Run linkspector
            uses: umbrelladocs/action-linkspector@v1
            with:


### PR DESCRIPTION
This pull request updates the version of the `actions/checkout` GitHub Action from `v4` to `v5` across all workflow files and documentation. This ensures that all CI jobs use the latest version of the checkout action, which may include important fixes and improvements.

**CI workflow updates:**

* Updated all instances of `actions/checkout@v4` to `actions/checkout@v5` in the following workflow files:
  - `.github/workflows/depup.yml`
  - `.github/workflows/labels.yml`
  - `.github/workflows/release.yml` [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L17-R17) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R54)
  - `.github/workflows/reviewdog.yml` [[1]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dL12-R12) [[2]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dL28-R35)
  - `.github/workflows/test.yml` [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L15-R15) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L27-R27) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L39-R39)
  - `.github/workflows/update-linkspector-version.yml`

**Documentation update:**

* Updated the example workflow in `README.md` to use `actions/checkout@v5` instead of `v4`.