### PR TITLE
pin dependent actions to sha

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -10,8 +10,10 @@ jobs:
   reviewdog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: reviewdog/action-depup/with-pr@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5 # v1
         with:
           file: action.yml
           version_name: reviewdog_version

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Manage labels
-        uses: lannonbr/issue-label-manager-action@4.0.0
+        uses: lannonbr/issue-label-manager-action@e8dbcd8198e86a1e98d5372e55db976fed9ba6f7 # 4.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,24 +14,26 @@ jobs:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
       - id: bumpr
         if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: haya14busa/action-bumpr@v1
+        uses: haya14busa/action-bumpr@faf6f474bcb6174125cfc569f0b2e24cbf03d496 # v1
 
       # Update corresponding major and minor tag.
       # e.g. Update v1 and v1.2 when releasing v1.2.3
-      - uses: haya14busa/action-update-semver@v1
+      - uses: haya14busa/action-update-semver@7d2c558640ea49e798d46539536190aff8c18715 # v1
         if: "!steps.bumpr.outputs.skip"
         with:
           tag: ${{ steps.bumpr.outputs.next_version }}
 
       # Get tag name.
       - id: tag
-        uses: haya14busa/action-cond@v1
+        uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1
         with:
           cond: "${{ startsWith(github.ref, 'refs/tags/') }}"
           if_true: ${{ github.ref }}
@@ -51,6 +53,8 @@ jobs:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Post bumpr status comment
-        uses: haya14busa/action-bumpr@v1
+        uses: haya14busa/action-bumpr@faf6f474bcb6174125cfc569f0b2e24cbf03d496 # v1

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,14 +9,16 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: haya14busa/action-cond@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1
         id: reporter
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: "github-pr-review"
           if_false: "github-check"
-      - uses: reviewdog/action-shellcheck@v1
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1
         with:
           reporter: ${{ steps.reporter.outputs.value }}
           level: warning
@@ -25,15 +27,19 @@ jobs:
     name: runner / shfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: reviewdog/action-shfmt@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: reviewdog/action-shfmt@d8f080930b9be5847b4f97e9f4122b81a82aaeac # v1
 
   actionlint:
     name: runner / actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: reviewdog/action-actionlint@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
           reporter: github-check
           level: warning

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,9 @@ jobs:
     name: runner / linkspector (github-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -24,7 +26,9 @@ jobs:
     name: runner / linkspector (github-pr-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -36,7 +40,9 @@ jobs:
     name: runner / linkspector (github-pr-review)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: ./
         continue-on-error: true
         with:

--- a/.github/workflows/update-linkspector-version.yml
+++ b/.github/workflows/update-linkspector-version.yml
@@ -11,19 +11,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Get current linkspector version from script
         id: get_current_version
         run: |
           current_version=$(grep -oP '@umbrelladocs/linkspector@\K[0-9]+\.[0-9]+\.[0-9]+' script.sh)
-          echo "CURRENT_VERSION=$current_version" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$current_version" >> "$GITHUB_ENV"
 
       - name: Fetch latest linkspector version from NPM
         id: get_latest_version
         run: |
           latest_version=$(npm view @umbrelladocs/linkspector version)
-          echo "LATEST_VERSION=$latest_version" >> $GITHUB_ENV
+          echo "LATEST_VERSION=$latest_version" >> "$GITHUB_ENV"
 
       - name: Compare versions and determine bump type
         id: compare_versions
@@ -31,13 +33,13 @@ jobs:
           echo "Current version: $CURRENT_VERSION"
           echo "Latest version: $LATEST_VERSION"
 
-          current_major=$(echo $CURRENT_VERSION | cut -d'.' -f1)
-          current_minor=$(echo $CURRENT_VERSION | cut -d'.' -f2)
-          current_patch=$(echo $CURRENT_VERSION | cut -d'.' -f3)
+          current_major=$(echo "$CURRENT_VERSION" | cut -d'.' -f1)
+          current_minor=$(echo "$CURRENT_VERSION" | cut -d'.' -f2)
+          current_patch=$(echo "$CURRENT_VERSION" | cut -d'.' -f3)
 
-          latest_major=$(echo $LATEST_VERSION | cut -d'.' -f1)
-          latest_minor=$(echo $LATEST_VERSION | cut -d'.' -f2)
-          latest_patch=$(echo $LATEST_VERSION | cut -d'.' -f3)
+          latest_major=$(echo "$LATEST_VERSION" | cut -d'.' -f1)
+          latest_minor=$(echo "$LATEST_VERSION" | cut -d'.' -f2)
+          latest_patch=$(echo "$LATEST_VERSION" | cut -d'.' -f3)
 
           echo "Current major: $current_major"
           echo "Current minor: $current_minor"
@@ -48,19 +50,19 @@ jobs:
           echo "Latest patch: $latest_patch"
 
           if [ "$latest_major" -ne "$current_major" ]; then
-            echo "VERSION_BUMP=bump:major" >> $GITHUB_ENV
+            echo "VERSION_BUMP=bump:major" >> "$GITHUB_ENV"
           elif [ "$latest_minor" -ne "$current_minor" ]; then
-            echo "VERSION_BUMP=bump:minor" >> $GITHUB_ENV
+            echo "VERSION_BUMP=bump:minor" >> "$GITHUB_ENV"
           elif [ "$latest_patch" -ne "$current_patch" ]; then
-            echo "VERSION_BUMP=bump:patch" >> $GITHUB_ENV
+            echo "VERSION_BUMP=bump:patch" >> "$GITHUB_ENV"
           else
-            echo "VERSION_BUMP=bump:patch" >> $GITHUB_ENV
+            echo "VERSION_BUMP=bump:patch" >> "$GITHUB_ENV"
           fi
 
           if [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
-            echo "NEW_VERSION_AVAILABLE=true" >> $GITHUB_ENV
+            echo "NEW_VERSION_AVAILABLE=true" >> "$GITHUB_ENV"
           else
-            echo "NEW_VERSION_AVAILABLE=false" >> $GITHUB_ENV
+            echo "NEW_VERSION_AVAILABLE=false" >> "$GITHUB_ENV"
           fi
 
       - name: Update script with new version
@@ -74,7 +76,7 @@ jobs:
 
       - name: Create Pull Request if new version is available
         if: env.NEW_VERSION_AVAILABLE == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update linkspector version to ${{ env.LATEST_VERSION }}

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: 24
     - name: Set reviewdog version
@@ -59,13 +59,13 @@ runs:
       shell: bash
     - name: Cache reviewdog binary
       id: cache-reviewdog
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/reviewdog-bin
         key: reviewdog-${{ runner.os }}-${{ runner.arch }}-${{ steps.reviewdog-version.outputs.reviewdog_version }}
     - name: Install reviewdog
       if: steps.cache-reviewdog.outputs.cache-hit != 'true'
-      uses: reviewdog/action-setup@v1
+      uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1
       with:
         reviewdog_version: ${{ steps.reviewdog-version.outputs.reviewdog_version }}
     - name: Copy reviewdog to cache location


### PR DESCRIPTION
## Description

The PR pins the dependent actions to their version's SHA digests. This has long been recommended from the security perspective as the remote dependency is unlikely to be mutated with this pin.

With the recent [Trivy compromise](https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release), it is wise to enable release immutability and enforce actions to be pinned to a full-length commit SHA (both are per-repo options, I'd suggest turning on both here, too). The latter enforcement makes the linkspector action to permafail since it pins its deps by tag rather than a sha-digest.

## Possible follow-ups

See https://github.com/zizmorcore/zizmor if you're interested in static analysis for GH actions. There are still some finds for your GitHub workflows that I did not address.