### PR TITLE
fix: disable package manager cache for setup-node action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,7 @@ runs:
     - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: 24
+        package-manager-cache: false
     - name: Set reviewdog version
       id: reviewdog-version
       run: echo "reviewdog_version=v0.21.0" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes #54 

`actions/setup-node@v5` defaults `package-manager-cache` to `true`, which auto-detects the package manager
   from the user's `package.json` `packageManager` field. In v5, this detection covers npm, yarn, and pnpm. 
  When a user's project specifies a non-npm manager like `"packageManager": "yarn@3.1.1"`, setup-node tries 
  to run `yarn cache dir` using the global Yarn 1.x — which fails because Corepack isn't enabled, and Yarn
  1.x refuses to run when it sees the `packageManager` field.

  This action only needs Node.js to run `npm install -g @umbrelladocs/linkspector`. It never uses the      
  user's package manager or their project dependencies. Setting `package-manager-cache: false` disables the
  auto-detection, preventing setup-node from interacting with the user's package manager entirely.