### PR TITLE
chore: add permissions to workflow files and create new zizmor workflow

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -6,6 +6,10 @@ on:
     types: [depup]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   reviewdog:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   label:
     name: Manage GitHub labels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,14 @@ on:
     types:
       - labeled
 
+permissions: {}
+
 jobs:
   release:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -52,6 +56,9 @@ jobs:
   release-check:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -4,10 +4,17 @@ on:
     branches:
       - main
   pull_request:
+
+permissions: {}
+
 jobs:
   shellcheck:
     name: runner / shellcheck
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -26,6 +33,9 @@ jobs:
   shfmt:
     name: runner / shfmt
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -35,6 +45,9 @@ jobs:
   actionlint:
     name: runner / actionlint
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -43,3 +56,5 @@ jobs:
         with:
           reporter: github-check
           level: warning
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   test-check:
     name: runner / linkspector (github-check)
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -25,6 +30,10 @@ jobs:
     if: github.event_name == 'pull_request'
     name: runner / linkspector (github-pr-check)
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -39,6 +48,9 @@ jobs:
     if: github.event_name == 'pull_request'
     name: runner / linkspector (github-pr-review)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/update-linkspector-version.yml
+++ b/.github/workflows/update-linkspector-version.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 */12 * * *'  # Run every 12 hours
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-linkspector-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,19 @@
+name: zizmor
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: runner / zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e #v0.5.3


### PR DESCRIPTION
Based on the suggestions on #55 

- Adds a workflow to run static security analysis on workflows
- fix permission issues as suggested by zizmor