### PR TITLE
fix: add support for arm64 runners by installing system Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,100 @@
 [![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-action%20linkspector-brightgreen?style=for-the-badge)](https://github.com/marketplace/actions/run-linkspector-with-reviewdog)
 ![GitHub Release](https://img.shields.io/github/v/release/UmbrellaDocs/action-linkspector?style=for-the-badge)
+[![NPM](https://img.shields.io/npm/v/@umbrelladocs/linkspector?style=for-the-badge)](https://www.npmjs.com/package/@umbrelladocs/linkspector)
+[![MCP](https://img.shields.io/badge/MCP%20Server-Linkspector_MCP-brightgreen?logo=modelcontextprotocol&style=for-the-badge)](https://github.com/UmbrellaDocs/linkspector-mcp)
 <a href="https://liberapay.com/gaurav-nelson/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>
 
 # GitHub action: Run 💀Linkspector with 🐶Reviewdog
 
 This action runs [Linkspector](https://github.com/UmbrellaDocs/linkspector) with [Reviewdog](https://github.com/reviewdog/reviewdog) on pull requests to improve the quality of your content.
+
+## Used by
+
+<table>
+<tr>
+<td align="center" width="150">
+<a href="https://github.com/dotnet/source-build/blob/main/.github/workflows/check-markdown-links.yml">
+<img src="https://github.com/dotnet.png" width="50" height="50" alt="dotnet" /><br />
+<b>.NET</b><br />
+<sub>source-build</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/SAP/abap-file-formats/blob/main/.github/workflows/markdown-link-check.yml">
+<img src="https://github.com/SAP.png" width="50" height="50" alt="SAP" /><br />
+<b>SAP</b><br />
+<sub>abap-file-formats</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/open-telemetry/opentelemetry-ruby/blob/main/.github/workflows/ci-markdown-link.yml">
+<img src="https://github.com/open-telemetry.png" width="50" height="50" alt="OpenTelemetry" /><br />
+<b>OpenTelemetry</b><br />
+<sub>opentelemetry-ruby</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/finos/spring-bot/blob/spring-bot-master/.github/workflows/checklinks.yml">
+<img src="https://github.com/finos.png" width="50" height="50" alt="FINOS" /><br />
+<b>FINOS</b><br />
+<sub>spring-bot</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/dotnet/dotnet-docker/blob/main/.github/workflows/check-markdown-links.yml">
+<img src="https://github.com/dotnet.png" width="50" height="50" alt="dotnet" /><br />
+<b>.NET</b><br />
+<sub>dotnet-docker</sub>
+</a>
+</td>
+</tr>
+<tr>
+<td align="center" width="150">
+<a href="https://github.com/Azure-Samples/azure-spring-boot-samples/blob/main/.github/workflows/markdown-link-check.yml">
+<img src="https://github.com/Azure-Samples.png" width="50" height="50" alt="Azure" /><br />
+<b>Azure</b><br />
+<sub>spring-boot-samples</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/solarwinds/apm-ruby/blob/main/.github/workflows/ci-markdown-link.yml">
+<img src="https://github.com/solarwinds.png" width="50" height="50" alt="SolarWinds" /><br />
+<b>SolarWinds</b><br />
+<sub>apm-ruby</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/jenkinsci/autograding-plugin/blob/main/.github/workflows/check-md-links.yml">
+<img src="https://github.com/jenkinsci.png" width="50" height="50" alt="Jenkins" /><br />
+<b>Jenkins</b><br />
+<sub>autograding-plugin</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/riscv/learn/blob/main/.github/workflows/linkcheck.yml">
+<img src="https://github.com/riscv.png" width="50" height="50" alt="RISC-V" /><br />
+<b>RISC-V</b><br />
+<sub>learn</sub>
+</a>
+</td>
+<td align="center" width="150">
+<a href="https://github.com/vllm-project/llm-compressor/blob/main/.github/workflows/linkcheck.yml">
+<img src="https://github.com/vllm-project.png" width="50" height="50" alt="vLLM" /><br />
+<b>vLLM</b><br />
+<sub>llm-compressor</sub>
+</a>
+</td>
+</tr>
+<tr>
+<td align="center" colspan="5">
+<a href="https://github.com/search?q=uses%3A+umbrelladocs%2Faction-linkspector%40v1&type=code">
+<b>and many more...</b>
+</a>
+</td>
+</tr>
+</table>
+
+If you are using this on production, consider [buying me a coffee](https://liberapay.com/gaurav-nelson/) ☕.
 
 ## How to use
 
@@ -83,15 +173,20 @@ Default is `false`.
 
 **Note:** Enabling the `show_stats` option causes Linkspector to run twice: once for reporting and again to collect statistics. Using this will increase the total run time of the action.
 
-### Real-life usage samples
+## Self-hosted and `arm64` runners
 
-Following is a list of some of the repositories which are using GitHub Action -
-Markdown link check.
+This action automatically detects `arm64` runners and self-hosted runners where Puppeteer's bundled Chromium may not work. In these cases, it installs system Chromium using the appropriate package manager (`apt`, `dnf`, `yum`, `apk`, `zypper`, or `pacman`).
 
-1. [dotnet](https://github.com/dotnet/source-build/blob/main/.github/workflows/check-markdown-links.yml)
-1. [dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/main/.github/workflows/check-markdown-links.yml)
-1. [SAP](https://github.com/SAP/abap-file-formats/blob/main/.github/workflows/markdown-link-check.yml)
-1. [Open Telemetry](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/.github/workflows/ci-markdown-link.yml)
-1. [More](https://github.com/search?q=uses%3A+umbrelladocs%2Faction-linkspector%40v1&type=code)
+If your runner already has Chrome or Chromium installed, the action detects it and skips installation.
 
-If you are using this on production, consider [buying me a coffee](https://liberapay.com/gaurav-nelson/) ☕.
+If you need to point to a specific Chromium/Chrome binary, set the `PUPPETEER_EXECUTABLE_PATH` environment variable in your workflow to skip all automatic Chromium setup:
+
+```yaml
+- name: Run linkspector
+  uses: umbrelladocs/action-linkspector@v1
+  env:
+    PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
+  with:
+    github_token: ${{ secrets.github_token }}
+    reporter: github-pr-review
+```

--- a/script.sh
+++ b/script.sh
@@ -7,19 +7,99 @@ fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+# If the user has already set PUPPETEER_EXECUTABLE_PATH, respect it and skip
+# all Chromium setup.
+if [ -n "${PUPPETEER_EXECUTABLE_PATH}" ]; then
+  echo "Using user-provided Chromium at ${PUPPETEER_EXECUTABLE_PATH}"
+else
+
+USE_SYSTEM_CHROMIUM=false
+
+# Puppeteer's bundled Chromium does not support arm64 Linux.
+if [ "$(uname -m)" = "aarch64" ]; then
+  USE_SYSTEM_CHROMIUM=true
+fi
+
+# On Ubuntu 24.04, AppArmor restricts unprivileged user namespaces which
+# Chromium's sandbox requires. Try to disable the restriction; if we can't
+# (e.g. self-hosted runners without the sysctl), fall back to system Chromium
+# which ships with proper AppArmor profiles.
+# Reference: https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+if [ "${USE_SYSTEM_CHROMIUM}" = "false" ] && command -v lsb_release >/dev/null 2>&1 && [ "$(lsb_release -rs)" = "24.04" ]; then
+  if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+    echo '::group::🔗💀 Setting up Chrome Linux Sandbox'
+    echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+    echo 'Done'
+    echo '::endgroup::'
+  else
+    USE_SYSTEM_CHROMIUM=true
+  fi
+fi
+
+if [ "${USE_SYSTEM_CHROMIUM}" = "true" ]; then
+  echo '::group::🔗💀 Installing system Chromium'
+  echo "Reason: $(uname -m) runner or missing AppArmor sysctl"
+
+  # Check if Chromium is already installed
+  EXISTING_CHROMIUM=""
+  for bin in chromium-browser chromium google-chrome-stable google-chrome; do
+    if command -v "${bin}" >/dev/null 2>&1; then
+      EXISTING_CHROMIUM="$(which "${bin}")"
+      break
+    fi
+  done
+
+  if [ -n "${EXISTING_CHROMIUM}" ]; then
+    echo "System Chromium already installed at ${EXISTING_CHROMIUM} — skipping installation"
+  elif command -v apt-get >/dev/null 2>&1; then
+    # Debian, Ubuntu
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq chromium-browser || sudo apt-get install -y -qq chromium
+  elif command -v dnf >/dev/null 2>&1; then
+    # Fedora, RHEL 8+, CentOS Stream
+    sudo dnf install -y chromium
+  elif command -v yum >/dev/null 2>&1; then
+    # RHEL 7, older CentOS
+    sudo yum install -y chromium
+  elif command -v apk >/dev/null 2>&1; then
+    # Alpine
+    sudo apk add --no-cache chromium
+  elif command -v zypper >/dev/null 2>&1; then
+    # openSUSE, SLES
+    sudo zypper install -y chromium
+  elif command -v pacman >/dev/null 2>&1; then
+    # Arch
+    sudo pacman -S --noconfirm chromium
+  else
+    echo '::error::Could not detect package manager. Please install Chromium manually and set PUPPETEER_EXECUTABLE_PATH.'
+    exit 1
+  fi
+
+  export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+  # Find the Chromium binary — name varies by distro
+  for bin in chromium-browser chromium google-chrome-stable google-chrome; do
+    if command -v "${bin}" >/dev/null 2>&1; then
+      PUPPETEER_EXECUTABLE_PATH="$(which "${bin}")"
+      break
+    fi
+  done
+  export PUPPETEER_EXECUTABLE_PATH
+
+  if [ -z "${PUPPETEER_EXECUTABLE_PATH}" ]; then
+    echo '::error::Chromium was installed but the binary was not found in PATH.'
+    exit 1
+  fi
+
+  echo "Using system Chromium at ${PUPPETEER_EXECUTABLE_PATH}"
+  echo '::endgroup::'
+fi
+
+fi # end PUPPETEER_EXECUTABLE_PATH check
+
 echo '::group::🔗💀 Installing linkspector ... https://github.com/UmbrellaDocs/linkspector'
 npm install -g @umbrelladocs/linkspector@0.5.2
 echo '🔗💀 linkspector version:'
 linkspector --version
-echo '::endgroup::'
-
-echo '::group::🔗💀 Setting up Chrome Linux Sandbox'
-# Based on the instructions found here: https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-if [ "$(lsb_release -rs)" = "24.04" ]; then
-  echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-  echo 'Done'
-fi
-
 echo '::endgroup::'
 
 echo '::group:: Running linkspector with reviewdog 🐶 ...'


### PR DESCRIPTION
Fixes #44 

This pull request adds support for running the script on arm64 (aarch64) Linux runners by ensuring Puppeteer uses the system-installed Chromium browser instead of its bundled version, which does not support arm64. This change improves compatibility for CI/CD pipelines and development environments using arm64 architecture.

Platform compatibility:

* Added a conditional block in `script.sh` to detect if the runner is arm64 (`aarch64`), install the system `chromium-browser`, and configure Puppeteer to use it by setting the appropriate environment variables.