### PR TITLE
fix: updates cache step version to avoid getting node20/24 warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       shell: bash
     - name: Cache reviewdog binary
       id: cache-reviewdog
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/reviewdog-bin
         key: reviewdog-${{ runner.os }}-${{ runner.arch }}-${{ steps.reviewdog-version.outputs.reviewdog_version }}


### PR DESCRIPTION
This pull request updates from cache v4 to cache v5. 
The breaking change on that task being the migration from node 20 to 24.

The reason why we want to upgrade this here:
1. Avoid getting noisy warnings when workflow depending on this (linkspector) step run.
2. Avoid a potential future breakage when GitHub decides to flip node version for all tasks later this month.

Example warning message we're currently getting:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/