### PR TITLE
chore: bump linkspector version to 0.5.5 which uses puppeteer to 25.1.0

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -97,7 +97,7 @@ fi
 fi # end PUPPETEER_EXECUTABLE_PATH check
 
 echo '::group::🔗💀 Installing linkspector ... https://github.com/UmbrellaDocs/linkspector'
-npm install -g @umbrelladocs/linkspector@0.5.3
+npm install -g @umbrelladocs/linkspector@0.5.5
 echo '🔗💀 linkspector version:'
 linkspector --version
 echo '::endgroup::'


### PR DESCRIPTION
Fixes #62 

The chain of events:

  1. Around May 25, GitHub rolled out runner image 20260525.161, which bumped preinstalled Node from 24.15 to 24.16.0 (this
  is the image change baywet spotted in issue #62 — the Chrome version diff he found was a red herring).
  2. Your action.yml:55 uses actions/setup-node with node-version: 24, which resolves to the latest 24.x — so every run, on
  every action version, now gets 24.16.0. That's why pinning older versions of the action didn't help anyone.
  3. script.sh:100 runs npm install -g @umbrelladocs/linkspector@0.5.3, whose puppeteer: ^24.37.5 dependency downloads
  Chrome in its postinstall and unzips it with extract-zip — which silently fails on Node 24.16.

  This is confirmed upstream in puppeteer/puppeteer#15071 (https://github.com/puppeteer/puppeteer/issues/15071) (exact same
  error, ver. 148.0.7778.97, started on Node 24.16.0, works on 24.15.0) and traced to max-mapper/extract-zip#154
  (https://github.com/max-mapper/extract-zip/issues/154) ("Detected unsettled top-level await" — the breakage first shipped
  in Node 26 and was then backported into the 24.x line). The Puppeteer maintainer's verdict: upgrade to Puppeteer v25
  (which dropped extract-zip) or stay on Node 24.15.0.
  
  Linkspector v0.5.5 uses the new puppeteer version.